### PR TITLE
Add FIB support for FreeBSD and OpenBSD (I didn't test on OpenBSD):

### DIFF
--- a/doc/examples/mlvpn.conf.in
+++ b/doc/examples/mlvpn.conf.in
@@ -91,6 +91,8 @@ cleartext_data = 0
 [dsl1]
 bindhost = "0.0.0.0"
 bindport = 5080
+#bindfib = 0
+# This FreeBSD/OpenBSD option allows to use different fib for each link
 #remotehost = "10.2.3.4"
 #remoteport = 5080
 #bandwidth_upload = 61440

--- a/man/mlvpn.conf.5.ronn
+++ b/man/mlvpn.conf.5.ronn
@@ -95,7 +95,7 @@ The **[general]** section is reserved for global configuration.
     **100 or more** disables the loss tolerence system.
 
 
-### TUNNELS
+### TUNNELS
 Each tunnel must be declared in it's own section.
 
 The section name is mapped to the tunnel name. Example: "[adsl1]", "[adsl2]".
@@ -105,6 +105,10 @@ The section name is mapped to the tunnel name. Example: "[adsl1]", "[adsl2]".
 
   - _bindport_ = 5080
     Bind on a specific port. (client/server)
+
+  - _bindfib_ = 0
+    Select the fib (FreeBSD/OpenBSD only) to use. Avoid to configure source-
+    routing on clients
 
   - _remotehost_ = "1.2.3.4"
     Address of the remote host. (client)
@@ -127,7 +131,7 @@ The section name is mapped to the tunnel name. Example: "[adsl1]", "[adsl2]".
     Links defined with fallback_only will be connected at all times,
     but will only be used if all other tunnels are down. (client)
 
-### FILTERS
+### FILTERS
 
 **[filters]** section associate a bpf(4) filter to a specific interface.
 Filters are used when aggregation is used but you want to pass some traffic

--- a/src/config.c
+++ b/src/config.c
@@ -269,6 +269,7 @@ mlvpn_config(int config_file_fd, int first_time)
             } else if (strncmp(lastSection, "filters", 7) != 0) {
                 char *bindaddr;
                 char *bindport;
+                uint32_t bindfib = 0;
                 char *dstaddr;
                 char *dstport;
                 uint32_t bwlimit = 0;
@@ -284,6 +285,9 @@ mlvpn_config(int config_file_fd, int first_time)
                     _conf_set_str_from_conf(
                         config, lastSection, "bindport", &bindport, NULL,
                         "bind port is mandatory in server mode.\n", 1);
+                    _conf_set_uint_from_conf(
+                        config, lastSection, "bindfib", &bindfib, 0,
+                        NULL, 0);
                     _conf_set_str_from_conf(
                         config, lastSection, "remotehost", &dstaddr, NULL,
                         NULL, 0);
@@ -296,6 +300,9 @@ mlvpn_config(int config_file_fd, int first_time)
                         NULL, 0);
                     _conf_set_str_from_conf(
                         config, lastSection, "bindport", &bindport, NULL,
+                        NULL, 0);
+                     _conf_set_uint_from_conf(
+                        config, lastSection, "bindfib", &bindfib, 0,
                         NULL, 0);
                     _conf_set_str_from_conf(
                         config, lastSection, "remotehost", &dstaddr, NULL,
@@ -336,6 +343,7 @@ mlvpn_config(int config_file_fd, int first_time)
                               tmptun->name);
                         if ((! mystr_eq(tmptun->bindaddr, bindaddr)) ||
                                 (! mystr_eq(tmptun->bindport, bindport)) ||
+                                (tmptun->bindfib != bindfib) ||
                                 (! mystr_eq(tmptun->destaddr, dstaddr)) ||
                                 (! mystr_eq(tmptun->destport, dstport))) {
                             mlvpn_rtun_status_down(tmptun);
@@ -346,6 +354,9 @@ mlvpn_config(int config_file_fd, int first_time)
                         }
                         if (bindport) {
                             strlcpy(tmptun->bindport, bindport, sizeof(tmptun->bindport));
+                        }
+                        if (tmptun->bindfib != bindfib) {
+                            tmptun->bindfib = bindfib;
                         }
                         if (dstaddr) {
                             strlcpy(tmptun->destaddr, dstaddr, sizeof(tmptun->destaddr));
@@ -380,7 +391,7 @@ mlvpn_config(int config_file_fd, int first_time)
                 {
                     log_info("config", "%s tunnel added", lastSection);
                     mlvpn_rtun_new(
-                        lastSection, bindaddr, bindport, dstaddr, dstport,
+                        lastSection, bindaddr, bindport, bindfib, dstaddr, dstport,
                         default_server_mode, timeout, fallback_only,
                         bwlimit, loss_tolerence);
                 }

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -836,9 +836,11 @@ mlvpn_rtun_start(mlvpn_tunnel_t *t)
             log_warn(NULL, "%s socket creation error",
                 t->name);
         } else {
-#if defined(HAVE_FREEBSD) || defined(HAVE_OPENBSD)
-            /* Setting SO_SETFIB (fib) supported on FreeBSD and OpenBSD only */
+            /* Setting fib/routing-table is supported on FreeBSD and OpenBSD only */
+#if defined(HAVE_FREEBSD)
             if (setsockopt(fd, SOL_SOCKET, SO_SETFIB, &fib, sizeof(fib)) < 0)
+#elif defined(HAVE_OPENBSD)
+            if (setsockopt(fd, SOL_SOCKET, SO_RTABLE, &fib, sizeof(fib)) < 0)
             {
                 log_warnx(NULL, "Cannot set FIB %d for kernel socket", fib);
                 goto error;

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -612,7 +612,7 @@ mlvpn_rtun_write(EV_P_ ev_io *w, int revents)
 
 mlvpn_tunnel_t *
 mlvpn_rtun_new(const char *name,
-               const char *bindaddr, const char *bindport,
+               const char *bindaddr, const char *bindport, uint32_t bindfib,
                const char *destaddr, const char *destport,
                int server_mode, uint32_t timeout,
                int fallback_only, uint32_t bandwidth,
@@ -668,6 +668,7 @@ mlvpn_rtun_new(const char *name,
         strlcpy(new->bindaddr, bindaddr, sizeof(new->bindaddr));
     if (bindport)
         strlcpy(new->bindport, bindport, sizeof(new->bindport));
+    new->bindfib = bindfib;
     if (destaddr)
         strlcpy(new->destaddr, destaddr, sizeof(new->destaddr));
     if (destport)
@@ -795,6 +796,7 @@ static int
 mlvpn_rtun_start(mlvpn_tunnel_t *t)
 {
     int ret, fd = -1;
+    int fib = 0;
     char *addr, *port;
     struct addrinfo hints, *res;
 
@@ -803,9 +805,11 @@ mlvpn_rtun_start(mlvpn_tunnel_t *t)
     {
         addr = t->bindaddr;
         port = t->bindport;
+        fib = t->bindfib;
     } else {
         addr = t->destaddr;
         port = t->destport;
+        fib = t->bindfib;
     }
 
     /* Initialize hints */
@@ -832,6 +836,14 @@ mlvpn_rtun_start(mlvpn_tunnel_t *t)
             log_warn(NULL, "%s socket creation error",
                 t->name);
         } else {
+#if defined(HAVE_FREEBSD) || defined(HAVE_OPENBSD)
+            /* Setting SO_SETFIB (fib) supported on FreeBSD and OpenBSD only */
+            if (setsockopt(fd, SOL_SOCKET, SO_SETFIB, &fib, sizeof(fib)) < 0)
+            {
+                log_warnx(NULL, "Cannot set FIB %d for kernel socket", fib);
+                goto error;
+            }
+#endif
             t->fd = fd;
             break;
         }

--- a/src/mlvpn.h
+++ b/src/mlvpn.h
@@ -138,6 +138,7 @@ typedef struct mlvpn_tunnel_s
     char *name;           /* tunnel name */
     char bindaddr[MLVPN_MAXHNAMSTR]; /* packets source */
     char bindport[MLVPN_MAXPORTSTR]; /* packets port source (or NULL) */
+    uint32_t bindfib;     /* FIB number to use */
     char destaddr[MLVPN_MAXHNAMSTR]; /* remote server ip (can be hostname) */
     char destport[MLVPN_MAXPORTSTR]; /* remote server port */
     int fd;               /* socket file descriptor */
@@ -193,7 +194,7 @@ int mlvpn_rtun_wrr_reset(struct rtunhead *head, int use_fallbacks);
 mlvpn_tunnel_t *mlvpn_rtun_wrr_choose();
 mlvpn_tunnel_t *mlvpn_rtun_choose();
 mlvpn_tunnel_t *mlvpn_rtun_new(const char *name,
-    const char *bindaddr, const char *bindport,
+    const char *bindaddr, const char *bindport, uint32_t bindfib,
     const char *destaddr, const char *destport,
     int server_mode, uint32_t timeout,
     int fallback_only, uint32_t bandwidth,


### PR DESCRIPTION
Hi,
this change allow to avoid source-routing configuration by selecting directly the FIB to use for each ISP link (new parameter: bindfib) on FreeBSD.
Code tested with mlvpn-2.3.1 and this patch on FreeBSD only with this lab: http://bsdrp.net/documentation/examples/aggregating_multiple_isp_links_with_mlvpn
Feature SO_SETFIB should be available on OpenBSD too, but I didn't tested it.

I've fixed 2 non-breaking-space typo in the man page too: Are you a bépo user ? :-)