### PR TITLE
Add support for Darwin (OS X)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Principle of operations
 
 Compatibility
 =============
-Linux, OpenBSD, FreeBSD
+Linux, OpenBSD, FreeBSD, OSX
 
 Windows is *NOT* supported, but MLVPN runs on routers, so you can
 benefit from MLVPN on *ANY* operating system of course.

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,10 @@ case $host_os in
         AC_DEFINE(HAVE_BSD, 1, [BSD])
         bsd=true
     ;;
+    *darwin*)
+        AC_DEFINE(HAVE_DARWIN, 1, [DARWIN])
+        darwin=true
+    ;;
     *)
         AC_MSG_ERROR("Unsupported operating system.")
     ;;
@@ -91,6 +95,7 @@ esac
 
 AM_CONDITIONAL([LINUX], [test x$linux = xtrue])
 AM_CONDITIONAL([BSD], [test x$bsd = xtrue])
+AM_CONDITIONAL([DARWIN], [test x$darwin = xtrue])
 
 dnl Checks for library functions. Please keep in alphabetical order
 AC_CHECK_FUNCS([ \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,10 @@ if BSD
 mlvpn_SOURCES += tuntap_bsd.c
 endif
 
+if DARWIN
+mlvpn_SOURCES += tuntap_darwin.c
+endif
+
 if ENABLE_CONTROL
 mlvpn_SOURCES += control.c control.h
 endif

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -65,6 +65,16 @@
 #include <sys/endian.h>
 #endif
 
+#ifdef HAVE_DARWIN
+#include <libkern/OSByteOrder.h>
+#define be16toh OSSwapBigToHostInt16
+#define be32toh OSSwapBigToHostInt32
+#define be64toh OSSwapBigToHostInt64
+#define htobe16 OSSwapHostToBigInt16
+#define htobe32 OSSwapHostToBigInt32
+#define htobe64 OSSwapHostToBigInt64
+#endif
+
 /* GLOBALS */
 struct tuntap_s tuntap;
 char *_progname;

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -41,6 +41,8 @@
 #endif
 #ifdef HAVE_FREEBSD
  #define _NSIG _SIG_MAXSIG
+#elif defined(HAVE_DARWIN)
+ #define _NSIG NSIG
 #endif
 
 #include "privsep.h"

--- a/src/tuntap_darwin.c
+++ b/src/tuntap_darwin.c
@@ -1,0 +1,108 @@
+#include "includes.h"
+
+#include <err.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <net/if_utun.h>
+
+#include "buffer.h"
+#include "tuntap_generic.h"
+#include "tool.h"
+
+int
+mlvpn_tuntap_read(struct tuntap_s *tuntap)
+{
+    ssize_t ret;
+    u_char data[DEFAULT_MTU];
+    ret = read(tuntap->fd, &data, DEFAULT_MTU);
+    if (ret < 0) {
+        /* read error on tuntap is not recoverable. We must die. */
+        fatal("tuntap", "unrecoverable read error");
+    } else if (ret == 0) { /* End of file */
+        fatalx("tuntap device closed");
+    } else if (ret > tuntap->maxmtu)  {
+        log_warnx("tuntap",
+            "cannot send packet: too big %d/%d. truncating",
+            (uint32_t)ret, tuntap->maxmtu);
+        ret = tuntap->maxmtu;
+    }
+    return mlvpn_tuntap_generic_read(data, ret);
+}
+
+int
+mlvpn_tuntap_write(struct tuntap_s *tuntap)
+{
+    int len;
+    mlvpn_pkt_t *pkt;
+    circular_buffer_t *buf = tuntap->sbuf;
+
+    /* Safety checks */
+    if (mlvpn_cb_is_empty(buf))
+        fatalx("tuntap_write called with empty buffer");
+
+    pkt = mlvpn_pktbuffer_read(buf);
+    len = write(tuntap->fd, pkt->data, pkt->len);
+    if (len < 0)
+    {
+        log_warn("tuntap", "%s write error", tuntap->devname);
+    } else {
+        if (len != pkt->len)
+        {
+            log_warnx("tuntap", "%s write error: %d/%d bytes sent",
+               tuntap->devname, len, pkt->len);
+        } else {
+            log_debug("tuntap", "%s > sent %d bytes",
+               tuntap->devname, len);
+        }
+    }
+
+    return len;
+}
+
+int
+mlvpn_tuntap_alloc(struct tuntap_s *tuntap)
+{
+    char devname[8];
+    int fd;
+    int i;
+
+    for (i=0; i < 32; i++)
+    {
+        snprintf(devname, 5, "%s%d",
+                 tuntap->type == MLVPN_TUNTAPMODE_TAP ? "tap" : "tun", i);
+        snprintf(tuntap->devname, sizeof(tuntap->devname), "/dev/%s", devname);
+
+        if ((fd = priv_open_tun(tuntap->type,
+                tuntap->devname, tuntap->maxmtu)) > 0 )
+            break;
+    }
+
+    if (fd <= 0)
+    {
+        log_warnx("tuntap",
+            "unable to open any /dev/%s0 to 32 read/write. "
+            "please check permissions.",
+            tuntap->type == MLVPN_TUNTAPMODE_TAP ? "tap" : "tun");
+        return fd;
+    }
+    tuntap->fd = fd;
+
+    strlcpy(tuntap->devname, devname, sizeof(tuntap->devname));
+    return tuntap->fd;
+}
+
+/* WARNING: called as root
+ *
+ * Really open the tun device.
+ * returns tun file descriptor.
+ *
+ * Compatibility: Darwin
+ */
+int
+root_tuntap_open(int tuntapmode, char *devname, int mtu)
+{
+    int fd;
+
+    fd = open(devname, O_RDWR);
+    return fd;
+}


### PR DESCRIPTION
This adds support for OSX.

OSX `tun`/`tap` interfaces don't require the protocol before each packet, but devices have to be directly accessed as on BSD systems.