### PR TITLE
Use the correct size for the device name on BSD

### DIFF
--- a/src/tuntap_bsd.c
+++ b/src/tuntap_bsd.c
@@ -92,7 +92,7 @@ mlvpn_tuntap_alloc(struct tuntap_s *tuntap)
     {
         snprintf(devname, 5, "%s%d",
                  tuntap->type == MLVPN_TUNTAPMODE_TAP ? "tap" : "tun", i);
-        snprintf(tuntap->devname, 10, "/dev/%s", devname);
+        snprintf(tuntap->devname, sizeof(tuntap->devname), "/dev/%s", devname);
 
         if ((fd = priv_open_tun(tuntap->type,
                 tuntap->devname, tuntap->maxmtu)) > 0 )


### PR DESCRIPTION
10 was actually off by one byte in order to store devices up to `i=32`, so only up to `/dev/tun9` could be used.

Just use the actual maximum device size instead of a hardcoded number.