### PR TITLE
A couple of bandwidth_upload-related fixes

### DIFF
--- a/doc/examples/mlvpn.conf.in
+++ b/doc/examples/mlvpn.conf.in
@@ -95,6 +95,8 @@ bindport = 5080
 #bindfib = 0
 #remotehost = "10.2.3.4"
 #remoteport = 5080
+## Bandwidth of this link, in bytes/s. If not specified, each link will only
+## receive as much traffic as the slowest link can handle.
 #bandwidth_upload = 61440
 #timeout = 25
 

--- a/doc/source/what_is_mlvpn.rst
+++ b/doc/source/what_is_mlvpn.rst
@@ -33,6 +33,10 @@ Limitations
 
 Non equivalent links (3G/4G and *DSL or WIFI and *DSL)
 ======================================================
+
+Note: make sure you set the bandwidth_upload on each link, otherwise each link
+will only receive as much traffic as the slowest link can handle.
+
 mlvpn can aggregate very different links if reordering is enabled.
 
 If you have a high latency 3G/4G link and a DSL connection, then

--- a/man/mlvpn.conf.5.ronn
+++ b/man/mlvpn.conf.5.ronn
@@ -122,7 +122,11 @@ The section name is mapped to the tunnel name. Example: "[adsl1]", "[adsl2]".
     Bandwidth is specified in Bytes (1 KiB is 1024 Bytes).
 
     This is used to setup the weighted round-robin balancing algorithm.
-    Set 0 if both links are similar. (client/server)
+
+    If not specified, each link will only receive as much traffic as the
+    slowest link can handle.
+
+    Set to 0 if both links have the same bandwidth. (client/server)
 
   - _timeout_ = 25
     Override **[general]** timeout for this link. (client/server)

--- a/src/control.c
+++ b/src/control.c
@@ -425,7 +425,7 @@ void mlvpn_control_write_status(struct mlvpn_control *ctrl)
                        t->recvpackets,
                        t->sentbytes,
                        t->recvbytes,
-                       0,
+                       t->bandwidth,
                        (uint32_t)t->srtt,
                        mlvpn_loss_ratio(t),
                        t->disconnects,


### PR DESCRIPTION
It took me a while to figure out why configuring `bandwidth_upload` is necessary and what would happen if one didn’t configure it, so here are a bunch of small improvements on the documentation.
