### PR TITLE
Send keepalives every 1s, detect timeouts at 2s

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -156,9 +156,9 @@ mlvpn_config(int config_file_fd, int first_time)
                 _conf_set_uint_from_conf(
                     config, lastSection, "timeout", &default_timeout, 60,
                     NULL, 0);
-                if (default_timeout < 5) {
-                    log_warnx("config", "timeout capped to 5 seconds");
-                    default_timeout = 5;
+                if (default_timeout < 2) {
+                    log_warnx("config", "timeout capped to 2 seconds");
+                    default_timeout = 2;
                 }
 
                 _conf_set_uint_from_conf(
@@ -317,9 +317,9 @@ mlvpn_config(int config_file_fd, int first_time)
                 _conf_set_uint_from_conf(
                     config, lastSection, "timeout", &timeout, default_timeout,
                     NULL, 0);
-                if (timeout < 5) {
-                    log_warnx("config", "timeout capped to 5 seconds");
-                    timeout = 5;
+                if (timeout < 2) {
+                    log_warnx("config", "timeout capped to 2 seconds");
+                    timeout = 2;
                 }
                 _conf_set_uint_from_conf(
                     config, lastSection, "loss_tolerence", &loss_tolerence,

--- a/src/mlvpn.h
+++ b/src/mlvpn.h
@@ -76,7 +76,7 @@
  */
 #define MLVPN_IO_TIMEOUT_INCREMENT 2
 
-#define NEXT_KEEPALIVE(now, t) (now + 2)
+#define NEXT_KEEPALIVE(now, t) (now + 1)
 /* Protocol version of mlvpn
  * version 0: mlvpn 2.0 to 2.1 
  * version 1: mlvpn 2.2+ (add reorder field in mlvpn_proto_t)


### PR DESCRIPTION
This results in (86400*86 / 2) / 1024 / 1024 = 3.5 MiB/day of additional
traffic per tunnel (keepalive packets are 86 bytes).

Detecting timeouts more quickly reduces the time during which
connections are stuck, resulting in a more pleasant user experience.
