### PR TITLE
Parse 5-digit ports

### DIFF
--- a/src/mlvpn.h
+++ b/src/mlvpn.h
@@ -47,7 +47,7 @@
 #include "timestamp.h"
 
 #define MLVPN_MAXHNAMSTR 256
-#define MLVPN_MAXPORTSTR 5
+#define MLVPN_MAXPORTSTR 6
 
 /* Number of packets in the queue. Each pkt is ~ 1520 */
 /* 1520 * 128 ~= 24 KBytes of data maximum per channel VMSize */


### PR DESCRIPTION
I tried MLVPN with a 5-digit port , but it has been trimmed to 4-digit number.

I did not debug the code, since my change solved the problem. But this is my guess what went wrong:

#define MLVPN_MAXPORTSTR 5
char destport[MLVPN_MAXPORTSTR];
strlcpy(tmptun->destport, dstport, sizeof(tmptun->destport));

strlcpy guarantee to NUL-terminate the result, which leaves only 4 characters for the port