### PR TITLE
Fix calculation of loss ration with sequence of tunnel

### DIFF
--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -477,7 +477,7 @@ mlvpn_protocol_read(
     if (proto.version >= 1) {
         decap_pkt->reorder = proto.reorder;
         decap_pkt->seq = be64toh(proto.data_seq);
-        mlvpn_loss_update(tun, decap_pkt->seq);
+        mlvpn_loss_update(tun, proto.seq);
     } else {
         decap_pkt->reorder = 0;
         decap_pkt->seq = 0;
@@ -501,8 +501,9 @@ mlvpn_protocol_read(
                 tun->srtt = (1 - alpha) * tun->srtt + (alpha * R);
             }
         }
-        log_debug("rtt", "%ums srtt %ums loss ratio: %d",
-            (unsigned int)R, (unsigned int)tun->srtt, mlvpn_loss_ratio(tun));
+        log_debug("rtt", "%s %ums srtt %ums loss ratio: %d seqvect: %016lx",
+            tun->name, (unsigned int)R, (unsigned int)tun->srtt,
+            mlvpn_loss_ratio(tun), tun->seq_vect);
     }
     return 0;
 fail:


### PR DESCRIPTION
Hi,
using the global sequence number to calculate the loss ratio for individual tunnels does not work. In case of a 8 tunnel setup the min loss is 82% as only every 8th packet will be on THAT tunnel.

Use the proto.seq not data_seq for loss calculation.

Flo