### PR TITLE
add nix flake for reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,38 @@ chmod +x /etc/init.d/mlvpn
 insserv mlvpn
 ```
 
-### Build from source
+## Build from source (using nix)
+Using nix, MLVPN can be built on any linux system without the need to manually setup a build environment or install dependencies.
+It also allows to build static binaries and cross built binaries.
+It just requires nix to be installed (see [getting nix](https://nixos.org/download.html))
+
+First obtain a flakes compatible nix  :
+```sh
+  nix-shell -p nixFlakes
+```
+Build MLVPN via nix:
+
+  - Build for your current platform  
+    ```sh
+      nix build github:zehome/MLVPN
+    ```
+  - Static build for your current platform  
+    ```sh
+      nix build github:zehome/MLVPN#mlvpn-static
+    ```
+  - Cross build for another platform
+    ```sh
+      nix build github:zehome/MLVPN#mlvpn-aarch64-linux
+    ```
+  - Static cross build for another platform
+    ```sh
+      nix build github:zehome/MLVPN#mlvpn-static-aarch64-linux
+    ```
+The binary will end up in `./result/bin`
+
+
+## Build from source (debian / arch)
+
 ```sh
 # Debian
 $ sudo apt-get install build-essential make autoconf libev-dev libsodium-dev libpcap-dev pkg-config

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ It just requires nix to be installed (see [getting nix](https://nixos.org/downlo
 
 First obtain a flakes compatible nix  :
 ```sh
-  nix-shell -p nixFlakes
+  NIX_CONFIG="experimental-features = flakes nix-command" nix-shell -p nixFlakes
 ```
 Build MLVPN via nix:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1616174264,
+        "narHash": "sha256-88Pu2xh1p2tixNxdijfqoCqq9ymkEx0d6jc7ycWavLo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5e8bdd07d1afaabf6b37afc5497b1e498b8046f",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,14 @@
   };
 
   outputs = inp:
-    let 
+    let
+      lib = inp.nixpkgs.lib;
       systems = [ "aarch64-linux" "armv7l-linux" "x86_64-linux" ];
+      
       pkgsForSystem = system: inp.nixpkgs.legacyPackages."${system}";
       pkgsCross = system: crossSystem: import inp.nixpkgs {
         inherit system crossSystem;
       };
-      lib = inp.nixpkgs.lib;
       buildFor = pkgs: pkgs.stdenv.mkDerivation {
         src = ./.;
         name = "mlvpn";
@@ -31,25 +32,28 @@
     in
       rec {
         defaultPackage = lib.genAttrs systems (system: packages."${system}".mlvpn);
-        packages = lib.genAttrs systems (system: 
+        packages = lib.genAttrs systems (system:
+          let 
+            otherSystems = builtins.filter (s: s != system) systems;
+          in
           {
             mlvpn = buildFor (pkgsForSystem system);
             mlvpn-static = buildFor (pkgsForSystem system).pkgsStatic;
           }
 
           # cross compiled packages
-          // (lib.listToAttrs (map (crossSystem:
-            lib.nameValuePair
-              "mlvpn-${crossSystem}"
-              (buildFor (pkgsCross system crossSystem))
-          ) (builtins.filter (s: s != system) systems) ))
+          //
+          (lib.listToAttrs (map (crossSystem: lib.nameValuePair
+            "mlvpn-${crossSystem}"
+            (buildFor (pkgsCross system crossSystem))
+          ) otherSystems ))
           
           # cross compiled static packages
-          // (lib.listToAttrs (map (crossSystem:
-            lib.nameValuePair
-              "mlvpn-static-${crossSystem}"
-              (buildFor (pkgsCross system crossSystem).pkgsStatic)
-          ) (builtins.filter (s: s != system) systems) ))
+          //
+          (lib.listToAttrs (map (crossSystem: lib.nameValuePair
+            "mlvpn-static-${crossSystem}"
+            (buildFor (pkgsCross system crossSystem).pkgsStatic)
+          ) otherSystems ))
         );
       };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs = inp:
+    let
+      pkgs = inp.nixpkgs.legacyPackages.x86_64-linux;
+    in
+    {
+      defaultPackage.x86_64-linux = pkgs.stdenv.mkDerivation {
+        src = ./.;
+        name = "mlvpn";
+        buildInputs = with pkgs; [
+          automake
+          autoconf
+          libev
+          libsodium
+          libpcap
+          pkg-config
+        ];
+        preConfigure = ''
+          ./autogen.sh
+        '';
+      };
+    };
+}

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -778,7 +778,7 @@ sig_got_chld(int sig)
     pid_t    pid;
 
     do {
-        pid = waitpid(WAIT_ANY, NULL, WNOHANG);
+        pid = waitpid(-1, NULL, WNOHANG);
         if (pid == child_pid && cur_state < STATE_QUIT)
             cur_state = STATE_QUIT;
     } while (pid > 0 || (pid == -1 && errno == EINTR));


### PR DESCRIPTION
With this, the project can be built reproducibly on any linux system which has the nix package manager installed,
using a single command:
```
nix-shell -p nixFlakes --run "nix build github:zehome/MLVPN"
```

Besides the reproducibility aspect, the benefit of this is, that any kind of build instructions become obsolete. No build dependencies need to be installed by the user, etc...
