### PR TITLE
Adding latency tolerance

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,11 +54,11 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - run: |
-       apt-get install build-essential make autoconf libev-dev libsodium-dev libpcap-dev pkg-config
+       sudo apt-get install build-essential make autoconf libev-dev libsodium-dev libpcap-dev pkg-config
        ./autogen.sh
        ./configure
        make
-       make install
+       sudo make install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,19 +53,13 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build
+    - run: |
+       apt-get install build-essential make autoconf libev-dev libsodium-dev libpcap-dev pkg-config
+       ./autogen.sh
+       ./configure
+       make
+       make install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,13 +47,12 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Build
     - run: |
        apt-get install build-essential make autoconf libev-dev libsodium-dev libpcap-dev pkg-config
        ./autogen.sh

--- a/doc/examples/mlvpn.conf.in
+++ b/doc/examples/mlvpn.conf.in
@@ -71,6 +71,12 @@ cleartext_data = 0
 # This value is expressed in percent.
 #loss_tolerence = 10
 
+# Latency tolerence
+# Defines the maximum latency accepted before the link affected is being
+# considered too slow and removed from agregation.
+# This value is expressed in milliseconds.
+#latency_tolerence = 10
+
 # Filtering system
 # when MLVPN is configured to balance traffic across multiple links
 # It may be required to force some traffic (VoIP) through a specific
@@ -107,6 +113,9 @@ bindport = 5080
 # If it is a lossy link and we want to keep using it,
 # even if 30% of packets are lost
 #loss_tolerence = 30
+# If it is a slow link and we want to keep using it,
+# even if the SRTT is 300ms
+#latency_tolerence = 300
 #bandwidth_upload = 512000
 
 #[dsl2]

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -102,7 +102,7 @@ Tunnel prefix reference
 -----------------------
     * '!' means down
     * '@' means up & running
-    * '~' means up but lossy (above the configured threshold)
+    * '~' means up but lossy or slow (above the configured threshold)
 
 Hot reloading mlvpn configuration
 =================================

--- a/doc/source/linux_example.rst
+++ b/doc/source/linux_example.rst
@@ -327,6 +327,7 @@ Take a look at example config files for more details. (**man mlvpn.conf** can be
     password = "you have not changed me yet?"
     reorder_buffer_size = 64
     loss_tolerence = 50
+    latency_tolerence = 250
 
     [filters]
 
@@ -402,6 +403,7 @@ mlvpn0.conf
     password = "pleasechangeme!"
     reorder_buffer_size = 64
     loss_tolerence = 50
+    latency_tolerence = 250
 
     [filters]
 

--- a/man/mlvpn.conf.5
+++ b/man/mlvpn.conf.5
@@ -105,7 +105,16 @@ Experiment to know what value is best for you\. Good starting point can be as sm
 \fIloss_tolerence\fR = 0 mlvpn monitors packet loss on every link\. If the packet loss ratio on a link exceed the specified value in percent, the link changes state to MLVPN_LOSSY and is removed from aggregation\.
 .
 .IP
-Lossy links ARE used anyway if no other choices are available (if all links are lossy)
+Lossy links ARE used anyway if no other choices are available (if all links are slow or lossy)
+.
+.IP
+\fB100 or more\fR disables the loss tolerence system\.
+.
+.IP "\(bu" 4
+\fIlatency_tolerence\fR = 0 mlvpn monitors smoothed round trip time on every link\. If the SRTT on a link exceeds the specified value in milliseconds, the link changes state to MLVPN_HIGH_LATENCY and is removed from aggregation\.
+.
+.IP
+Slow links ARE used anyway if no other choices are available (if all links are slow or lossy)
 .
 .IP
 \fB100 or more\fR disables the loss tolerence system\.
@@ -172,13 +181,13 @@ The reorder buffer will be sent "as is" on the network if the buffer can\'t be r
 MLVPN status can be monitored by using ps\. mlvpn prints it\'s \-\-name, then the status of each tunnel prefixed by the status\.
 .
 .P
-Status availables: \fB!\fR: down, \fB@\fR: up, \fB~\fR: lossy
+Status availables: \fB!\fR: down, \fB@\fR: up, \fB~\fR: lossy or slow
 .
 .P
 Example: \fBmlvpn: adsl3g !3g @adsl ~wifi\fR
 .
 .P
-3g is \fBdown\fR, adsl is \fBup\fR and wifi is \fBlossy\fR (up, but above loss_tolerence threshold)\.
+3g is \fBdown\fR, adsl is \fBup\fR and wifi is \fBlossy or slow\fR (up, but above loss_tolerence or latency_tolerance threshold)\.
 .
 .SH "EXAMPLE"
 See examples/mlvpn\.conf

--- a/man/mlvpn.conf.5
+++ b/man/mlvpn.conf.5
@@ -106,6 +106,9 @@ Experiment to know what value is best for you\. Good starting point can be as sm
 .
 .IP
 Lossy links ARE used anyway if no other choices are available (if all links are slow or lossy)
+.IP
+Values must be the same in the configuration on both sides of the link, this affects outbound traffic scheduling only. If only the client has this setting, lossy links will lead to upload data being disabled. In a video call for example, you will still receive traffic on the lossy link.
+.
 .
 .IP
 \fB100 or more\fR disables the loss tolerence system\.
@@ -115,9 +118,11 @@ Lossy links ARE used anyway if no other choices are available (if all links are 
 .
 .IP
 Slow links ARE used anyway if no other choices are available (if all links are slow or lossy)
+.IP
+Values must be the same in the configuration on both sides of the link, this affects outbound traffic scheduling only. If only the client has this setting, high latency situations will lead to upload data being disabled. In a video call for example, you will still receive traffic on the high latency link.
 .
 .IP
-\fB100 or more\fR disables the loss tolerence system\.
+\fB1000 or more\fR disables the loss tolerence system\.
 .
 .IP "" 0
 .

--- a/man/mlvpn.conf.5.ronn
+++ b/man/mlvpn.conf.5.ronn
@@ -92,7 +92,24 @@ The **[general]** section is reserved for global configuration.
     Lossy links ARE used anyway if no other choices are available (if all links
     are lossy)
 
+    This setting affects outbound traffic only, streaming UDP data such as video
+    calling will still receive traffic if this setting is not reflected in the
+    configuration on both sides of the link
+
     **100 or more** disables the loss tolerence system.
+
+  - _latency_tolerence_ = 0
+    mlvpn monitors packet latency on every link. If the packet latency
+    on a link exceeds the specified value in milliseconds,
+    the link changes state to MLVPN_HIGH_LATENCY and is removed from aggregation.
+
+    Slow links ARE used anyway if no other choices are available (if all links
+    are lossy)
+    This setting affects outbound traffic only, streaming UDP data such as video
+        calling will still receive traffic if this setting is not reflected in the
+        configuration on both sides of the link
+
+    **1000 or more** disables the latency tolerence system.
 
 
 ### TUNNELS

--- a/src/control.c
+++ b/src/control.c
@@ -407,6 +407,7 @@ void mlvpn_control_write_metrics(struct mlvpn_control *ctrl)
         control_writef("waitingpeer{tunnel=\"%s\"} %u\n", t->name, (t->status == MLVPN_AUTHSENT ? 1 : 0));
         control_writef("connected{tunnel=\"%s\"} %u\n", t->name, (t->status == MLVPN_AUTHOK ? 1 : 0));
         control_writef("lossy{tunnel=\"%s\"} %u\n", t->name, (t->status == MLVPN_LOSSY ? 1 : 0));
+        control_writef("slow{tunnel=\"%s\"} %u\n", t->name, (t->status == MLVPN_HIGH_LATENCY ? 1 : 0));
 
         control_writef("sentpackets{tunnel=\"%s\"} %" PRIu64 "\n", t->name, t->sentpackets);
         control_writef("recvpackets{tunnel=\"%s\"} %" PRIu64 "\n", t->name, t->recvpackets);

--- a/src/control.c
+++ b/src/control.c
@@ -451,6 +451,8 @@ void mlvpn_control_write_status(struct mlvpn_control *ctrl)
             status = "connected";
         else if (t->status == MLVPN_LOSSY)
             status = "lossy link";
+        else if (t->status == MLVPN_HIGH_LATENCY)
+            status = "slow link";
         else
             status = "unknown";
 

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -1330,6 +1330,7 @@ update_process_title()
             case MLVPN_AUTHOK:
                 s = "@";
                 break;
+            case MLVPN_HIGH_LATENCY:
             case MLVPN_LOSSY:
                 s = "~";
                 break;

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -1212,12 +1212,12 @@ mlvpn_rtun_check_slow(mlvpn_tunnel_t *tun)
 {
     int status_changed = 0;
     if (tun->srtt >= tun->latency_tolerence) {
-        log_info("rtt", "%s latency reached threashold: %f%%/%d%%",
+        log_info("rtt", "%s latency reached threashold: %fms/%dms",
                  tun->name, tun->srtt, tun->latency_tolerence);
         tun->status = MLVPN_HIGH_LATENCY;
         status_changed = 1;
     } else if (tun->srtt < tun->latency_tolerence && tun->status == MLVPN_HIGH_LATENCY) {
-        log_info("rtt", "%s latency acceptable again: %f%%/%d%%",
+        log_info("rtt", "%s latency acceptable again: %fms/%dms",
                  tun->name, tun->srtt, tun->latency_tolerence);
         tun->status = MLVPN_AUTHOK;
         status_changed = 1;

--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -628,7 +628,7 @@ mlvpn_rtun_new(const char *name,
                const char *destaddr, const char *destport,
                int server_mode, uint32_t timeout,
                int fallback_only, uint32_t bandwidth,
-               uint32_t loss_tolerence)
+               uint32_t loss_tolerence, uint32_t latency_tolerence)
 {
     mlvpn_tunnel_t *new;
 
@@ -676,6 +676,7 @@ mlvpn_rtun_new(const char *name,
     new->bandwidth = bandwidth;
     new->fallback_only = fallback_only;
     new->loss_tolerence = loss_tolerence;
+    new->latency_tolerence = latency_tolerence;
     if (bindaddr)
         strlcpy(new->bindaddr, bindaddr, sizeof(new->bindaddr));
     if (bindport)
@@ -1166,6 +1167,25 @@ mlvpn_rtun_send_disconnect(mlvpn_tunnel_t *t)
 }
 
 static void
+switch_to_fallback_if_necessary() {
+    mlvpn_tunnel_t *t;
+    LIST_FOREACH(t, &rtuns, entries) {
+        if (! t->fallback_only && t->status != MLVPN_HIGH_LATENCY && t->status != MLVPN_LOSSY) {
+            mlvpn_status.fallback_mode = 0;
+            mlvpn_rtun_wrr_reset(&rtuns, mlvpn_status.fallback_mode);
+            return;
+        }
+    }
+    if (mlvpn_options.fallback_available) {
+        log_info(NULL, "all tunnels are down, lossy or too slow, switch fallback mode");
+        mlvpn_status.fallback_mode = 1;
+        mlvpn_rtun_wrr_reset(&rtuns, mlvpn_status.fallback_mode);
+    } else {
+        log_info(NULL, "all tunnels are down, lossy or too slow but fallback is not available");
+    }
+}
+
+static void
 mlvpn_rtun_check_lossy(mlvpn_tunnel_t *tun)
 {
     int loss = mlvpn_loss_ratio(tun);
@@ -1181,23 +1201,30 @@ mlvpn_rtun_check_lossy(mlvpn_tunnel_t *tun)
         tun->status = MLVPN_AUTHOK;
         status_changed = 1;
     }
-    /* are all links in lossy mode ? switch to fallback ? */
+    /* are all links in high latency or lossy mode ? switch to fallback ? */
     if (status_changed) {
-        mlvpn_tunnel_t *t;
-        LIST_FOREACH(t, &rtuns, entries) {
-            if (! t->fallback_only && t->status != MLVPN_LOSSY) {
-                mlvpn_status.fallback_mode = 0;
-                mlvpn_rtun_wrr_reset(&rtuns, mlvpn_status.fallback_mode);
-                return;
-            }
-        }
-        if (mlvpn_options.fallback_available) {
-            log_info(NULL, "all tunnels are down or lossy, switch fallback mode");
-            mlvpn_status.fallback_mode = 1;
-            mlvpn_rtun_wrr_reset(&rtuns, mlvpn_status.fallback_mode);
-        } else {
-            log_info(NULL, "all tunnels are down or lossy but fallback is not available");
-        }
+        switch_to_fallback_if_necessary();
+    }
+}
+
+static void
+mlvpn_rtun_check_slow(mlvpn_tunnel_t *tun)
+{
+    int status_changed = 0;
+    if (tun->srtt >= tun->latency_tolerence) {
+        log_info("rtt", "%s latency reached threashold: %f%%/%d%%",
+                 tun->name, tun->srtt, tun->latency_tolerence);
+        tun->status = MLVPN_HIGH_LATENCY;
+        status_changed = 1;
+    } else if (tun->srtt < tun->latency_tolerence && tun->status == MLVPN_HIGH_LATENCY) {
+        log_info("rtt", "%s latency acceptable again: %f%%/%d%%",
+                 tun->name, tun->srtt, tun->latency_tolerence);
+        tun->status = MLVPN_AUTHOK;
+        status_changed = 1;
+    }
+    /* are all links in high latency or lossy mode ? switch to fallback ? */
+    if (status_changed) {
+        switch_to_fallback_if_necessary();
     }
 }
 
@@ -1221,6 +1248,7 @@ mlvpn_rtun_check_timeout(EV_P_ ev_timer *w, int revents)
         ev_io_start(EV_A_ &t->io_write);
     }
     mlvpn_rtun_check_lossy(t);
+    mlvpn_rtun_check_slow(t);
 }
 
 static void

--- a/src/mlvpn.h
+++ b/src/mlvpn.h
@@ -127,7 +127,8 @@ enum chap_status {
     MLVPN_DISCONNECTED,
     MLVPN_AUTHSENT,
     MLVPN_AUTHOK,
-    MLVPN_LOSSY
+    MLVPN_LOSSY,
+    MLVPN_HIGH_LATENCY
 };
 
 LIST_HEAD(rtunhead, mlvpn_tunnel_s);
@@ -149,6 +150,7 @@ typedef struct mlvpn_tunnel_s
     int conn_attempts;    /* connection attempts */
     int fallback_only;    /* if set, this link will be used when all others are down */
     uint32_t loss_tolerence; /* How much loss is acceptable before the link is discarded */
+    uint32_t latency_tolerence; /* How much latency is acceptable before the link is discarded */
     uint64_t seq;
     uint64_t expected_receiver_seq;
     uint64_t saved_timestamp;
@@ -200,7 +202,7 @@ mlvpn_tunnel_t *mlvpn_rtun_new(const char *name,
     const char *destaddr, const char *destport,
     int server_mode, uint32_t timeout,
     int fallback_only, uint32_t bandwidth,
-    uint32_t loss_tolerence);
+    uint32_t loss_tolerence, uint32_t latency_tolerence);
 void mlvpn_rtun_drop(mlvpn_tunnel_t *t);
 void mlvpn_rtun_status_down(mlvpn_tunnel_t *t);
 #ifdef HAVE_FILTERS

--- a/src/wrr.c
+++ b/src/wrr.c
@@ -47,7 +47,7 @@ int mlvpn_rtun_wrr_reset(struct rtunhead *head, int use_fallbacks)
             (t->status == MLVPN_AUTHOK))
         {
             if (wrr.len >= MAX_TUNNELS)
-                fatalx("You have too much tunnels declared");
+                fatalx("You have too many tunnels declared");
             wrr.tunnel[wrr.len] = t;
             wrr.tunval[wrr.len] = 0.0;
             wrr.len++;


### PR DESCRIPTION
Due to reduced throughput when a slow connection is part of the bonded group, I have been trialling an SRTT threshold. This has performed well on some test devices. I'm not entirely sure about the enum addition. I guess I'd rather change the existing value to `MLVPN_EXCLUDED` and have both the latency and the loss tolerance monitors use that rather than have their own