### PR TITLE
Don't check latency for tunnels which are down

### DIFF
--- a/src/mlvpn.c
+++ b/src/mlvpn.c
@@ -1214,7 +1214,7 @@ mlvpn_rtun_check_slow(mlvpn_tunnel_t *tun)
         return;
     }
     int status_changed = 0;
-    if (tun->srtt >= tun->latency_tolerence) {
+    if (tun->srtt >= tun->latency_tolerence && tun->status == MLVPN_AUTHOK) {
         log_info("rtt", "%s latency reached threashold: %fms/%dms",
                  tun->name, tun->srtt, tun->latency_tolerence);
         tun->status = MLVPN_HIGH_LATENCY;


### PR DESCRIPTION
Without this, my installation constantly logged `all tunnels are down, lossy or too slow, switch fallback mode` and no pings came through the tunnel.